### PR TITLE
Expand package.json to allow installation through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,32 @@
 {
-	"dependencies": {
-		"uuid": "*",
-		"esprima": "*",
-		"escodegen": "*",
-		"sync-request": "*",
-		"iconv-lite": "*",
-		"walk": "*",
-		"async": "*",
-		"minimist": "*"
-	},
-	"devDependencies": {
-		"eslint": "*",
-		"eslint-config-google": "*"
-	}
+  "name": "box-js",
+  "version": "1.0.0",
+  "description": "A tool for studying JavaScript malware.",
+  "dependencies": {
+    "uuid": "*",
+    "esprima": "*",
+    "escodegen": "*",
+    "sync-request": "*",
+    "iconv-lite": "*",
+    "walk": "*",
+    "async": "*",
+    "minimist": "*"
+  },
+  "devDependencies": {
+    "eslint": "*",
+    "eslint-config-google": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CapacitorSet/box-js.git"
+  },
+  "author": "CapacitorSet",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/CapacitorSet/box-js/issues"
+  },
+  "homepage": "https://github.com/CapacitorSet/box-js#readme",
+  "bin": {
+    "box-js": "run.js"
+  }
 }

--- a/run.js
+++ b/run.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var cp = require('child_process');
 var fs = require("fs");
 var walk = require("walk");


### PR DESCRIPTION
This will allow users to install box-js as a command-line tool through npm, once it has been published (which I haven't taken the liberty of doing, as this isn't my project):

```
$ npm install -g box-js
$ which box-js
/usr/bin/box-js
$ box-js
Using a 10 seconds timeout, pass --timeout to specify another timeout in seconds
Please pass one or more filenames or directories as an argument.
```

The package can be tested with `npm link`, and published by following the steps at https://docs.npmjs.com/getting-started/publishing-npm-packages