### PR TITLE
Enable passing path to output directory

### DIFF
--- a/run.js
+++ b/run.js
@@ -37,6 +37,9 @@ Arguments:
                           (e.g. \`typeof ActiveXObject\`, which must return
                           "unknown" in the JScript standard and not "object")
 
+    --output-dir=./       The location on disk to write the results files and
+                          folders to (defaults to current directory)
+
     --timeout=10          The script will timeout after this many seconds
                           (default 10)
 
@@ -54,6 +57,9 @@ if (argv.h || argv.help || argv.length === 0) {
 let timeout = argv.timeout || 10;
 if (!argv.timeout)
 	console.log("Using a 10 seconds timeout, pass --timeout to specify another timeout in seconds");
+
+let outputDir = argv["output-dir"] || "./";
+outputDir = outputDir.slice(-1) != "/" ? outputDir + "/" : outputDir;
 
 const isFile = path => {
 	try {
@@ -83,10 +89,10 @@ const tasks = process.argv
 				}
 			});
 			return files.map(
-				({root, name}) => analyze(root + name, name)
+				({root, name}) => analyze(root + name, name, outputDir)
 			);
 		} :
-		() => analyze(path, path)
+		() => analyze(path, path, outputDir)
 	);
 
 if (tasks.length === 0) {
@@ -107,12 +113,12 @@ function isDir(path) {
 	}
 }
 
-function analyze(path, filename) {
-	let directory = filename + ".results";
+function analyze(path, filename, outputDir) {
+	let directory = outputDir + filename + ".results";
 	let i = 1;
 	while (isDir(directory)) {
 		i++;
-		directory = filename + "." + i + ".results";
+		directory = outputDir + filename + "." + i + ".results";
 	}
 	fs.mkdirSync(directory);
 	directory += "/"; // For ease of use

--- a/run.js
+++ b/run.js
@@ -6,6 +6,51 @@ var walk = require("walk");
 
 var argv = require('minimist')(process.argv.slice(2));
 
+var help = `box-js is a utility to analyze malicious JavaScript files.
+
+Usage:
+    box-js <files|directories> [args]
+
+Arguments:
+    --download            Actually download the payloads
+
+    --no-cc_on-rewrite    Do not rewrite \`/\*@cc_on <...>@*/\` to \`<...>\`
+
+    --no-concat-simplify  Do not simplify \`"a"+"b"\` to \`"ab"\`
+
+    --no-echo             When the script prints data, do not print it to the
+                          console
+
+    --no-eval-rewrite     Do not rewrite \`eval\` so that its argument is
+                          rewritten
+
+    --no-rewrite          Do not rewrite the source doe at all, other than for
+                          \`@cc_on\` support
+
+    --no-shell-error      Do not throw a fake error when executing
+                          \`WScriptShell.Run\` (it throws a fake error by
+                          default to pretend that the distributions sites are
+                          down, so that the script will attempt to poll every
+                          site)
+
+    --no-typeof-rewrite   Do not rewrite \`typeof\`
+                          (e.g. \`typeof ActiveXObject\`, which must return
+                          "unknown" in the JScript standard and not "object")
+
+    --timeout=10          The script will timeout after this many seconds
+                          (default 10)
+
+    --windows-xp          Emulate Windows XP (influences the value of
+                          environment variables)
+
+    --experimental-neq    [experimental] rewrite \`a != b\` to \`false\`
+`;
+
+if (argv.h || argv.help || argv.length === 0) {
+    console.log(help);
+    process.exit(0);
+}
+
 let timeout = argv.timeout || 10;
 if (!argv.timeout)
 	console.log("Using a 10 seconds timeout, pass --timeout to specify another timeout in seconds");


### PR DESCRIPTION
The `run.js` file now takes another argument, `--output-dir`, which is the path to the directory in which to write all of the output JSON files (still in their folders named after the JS files).

```
$ box-js mlwr.js --output-dir=test/
Using a 10 seconds timeout, pass --timeout to specify another timeout in seconds
Analyzing mlwr.js
"hello, world"
$ tree test
test/
└── mlwr.js.results
    ├── 68627ea2-2475-4d5c-a3d3-6ab5dfbc0609.js
    └── snippets.json
```

As a side effect of this change, I've also improved the documentation that is available from the command-line (largely copying the appropriate sections from the README):

```
$ box-js --help
box-js is a utility to analyze malicious JavaScript files.

Usage:
    box-js <files|directories> [args]

Arguments:
    --download            Actually download the payloads

    --no-cc_on-rewrite    Do not rewrite `/*@cc_on <...>@*/` to `<...>`

    --no-concat-simplify  Do not simplify `"a"+"b"` to `"ab"`

    --no-echo             When the script prints data, do not print it to the
                          console

    --no-eval-rewrite     Do not rewrite `eval` so that its argument is
                          rewritten

    --no-rewrite          Do not rewrite the source doe at all, other than for
                          `@cc_on` support

    --no-shell-error      Do not throw a fake error when executing
                          `WScriptShell.Run` (it throws a fake error by
                          default to pretend that the distributions sites are
                          down, so that the script will attempt to poll every
                          site)

    --no-typeof-rewrite   Do not rewrite `typeof`
                          (e.g. `typeof ActiveXObject`, which must return
                          "unknown" in the JScript standard and not "object")

    --output-dir=./       The location on disk to write the results files and
                          folders to (defaults to current directory)

    --timeout=10          The script will timeout after this many seconds
                          (default 10)

    --windows-xp          Emulate Windows XP (influences the value of
                          environment variables)

    --experimental-neq    [experimental] rewrite `a != b` to `false`
```