### PR TITLE
Json documentation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ and iterate until the code emulates without errors.
 
 @CapacitorSet: Main developer
 
-@daviesjaime:
+@daviesjamie:
 
  * npm packaging
  * command-line help

--- a/flags.json
+++ b/flags.json
@@ -1,0 +1,50 @@
+[
+    {
+        "flag": "--download",
+        "description": "Actually download the payloads"
+    },
+    {
+        "flag": "--no-cc_on-rewrite",
+        "description": "Do not rewrite `/*@cc_on <...>@*/` to `<...>`"
+    },
+    {
+        "flag": "--no-concat-simplify",
+        "description": "Do not simplify `'a'+'b'` to `'ab'`"
+    },
+    {
+        "flag": "--no-echo",
+        "description": "When the script prints data, do not print it to the console"
+    },
+    {
+        "flag": "--no-eval-rewrite",
+        "description": "Do not rewrite `eval` so that its argument is rewritten"
+    },
+    {
+        "flag": "--no-rewrite",
+        "description": "Do not rewrite the source code at all, other than for `@cc_on` support"
+    },
+    {
+        "flag": "--no-shell-error",
+        "description": "Do not throw a fake error when executing `WScriptShell.Run` (it throws a fake error by default to pretend that the distribution sites are down, so that the script will attempt to poll every site)"
+    },
+    {
+        "flag": "--no-typeof-rewrite",
+        "description": "Do not rewrite `typeof` (e.g. `typeof ActiveXObject`, which must return 'unknown' in the JScript standard and not 'object')"
+    },
+    {
+        "flag": "--output-dir",
+        "description": "The location on disk to write the results files and folders to (defaults to the current directory)"
+    },
+    {
+        "flag": "--timeout",
+        "description": "The script will timeout after this many seconds (default 10)"
+    },
+    {
+        "flag": "--windows-xp",
+        "description": "Emulate Windows XP (influences the value of environment variables)"
+    },
+    {
+        "flag": "--experimental-neq",
+        "description": "[experimental] rewrite `a != b` to `false`"
+    }
+]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "iconv-lite": "*",
     "walk": "*",
     "async": "*",
-    "minimist": "*"
+    "minimist": "*",
+    "columnify": "*"
   },
   "devDependencies": {
     "eslint": "*",

--- a/run.js
+++ b/run.js
@@ -3,6 +3,7 @@
 var cp = require('child_process');
 var fs = require("fs");
 var walk = require("walk");
+var columnify = require("columnify");
 
 var argv = require('minimist')(process.argv.slice(2));
 
@@ -12,45 +13,21 @@ Usage:
     box-js <files|directories> [args]
 
 Arguments:
-    --download            Actually download the payloads
-
-    --no-cc_on-rewrite    Do not rewrite \`/\*@cc_on <...>@*/\` to \`<...>\`
-
-    --no-concat-simplify  Do not simplify \`"a"+"b"\` to \`"ab"\`
-
-    --no-echo             When the script prints data, do not print it to the
-                          console
-
-    --no-eval-rewrite     Do not rewrite \`eval\` so that its argument is
-                          rewritten
-
-    --no-rewrite          Do not rewrite the source code at all, other than for
-                          \`@cc_on\` support
-
-    --no-shell-error      Do not throw a fake error when executing
-                          \`WScriptShell.Run\` (it throws a fake error by
-                          default to pretend that the distributions sites are
-                          down, so that the script will attempt to poll every
-                          site)
-
-    --no-typeof-rewrite   Do not rewrite \`typeof\`
-                          (e.g. \`typeof ActiveXObject\`, which must return
-                          "unknown" in the JScript standard and not "object")
-
-    --output-dir=./       The location on disk to write the results files and
-                          folders to (defaults to current directory)
-
-    --timeout=10          The script will timeout after this many seconds
-                          (default 10)
-
-    --windows-xp          Emulate Windows XP (influences the value of
-                          environment variables)
-
-    --experimental-neq    [experimental] rewrite \`a != b\` to \`false\`
 `;
 
+// Read and format JSON flag documentation
+var flags = JSON.parse(fs.readFileSync('flags.json', 'utf8'));
+flags = columnify(flags, {
+    showHeaders: false,
+    config: {
+        description: {
+            maxWidth: 50
+        }
+    }
+});
+
 if (argv.h || argv.help || argv.length === 0) {
-    console.log(help);
+    console.log(help + flags.replace(/^/mg, "    "));
     process.exit(0);
 }
 


### PR DESCRIPTION
Store available command-line flags and their descriptions in a JSON file, which is parsed, formatted and inserted into the help text (fixes #5).

Uses [columnify](https://github.com/timoxley/columnify) to format the text into columns.

```
$ box-js -h
box-js is a utility to analyze malicious JavaScript files.

Usage:
    box-js <files|directories> [args]

Arguments:
    --download           Actually download the payloads
    --no-cc_on-rewrite   Do not rewrite `/*@cc_on <...>@*/` to `<...>`
    --no-concat-simplify Do not simplify `'a'+'b'` to `'ab'`
    --no-echo            When the script prints data, do not print it to
                         the console
    --no-eval-rewrite    Do not rewrite `eval` so that its argument is
                         rewritten
    --no-rewrite         Do not rewrite the source code at all, other than
                         for `@cc_on` support
    --no-shell-error     Do not throw a fake error when executing
                         `WScriptShell.Run` (it throws a fake error by
                         default to pretend that the distribution sites are
                         down, so that the script will attempt to poll
                         every site)
    --no-typeof-rewrite  Do not rewrite `typeof` (e.g. `typeof
                         ActiveXObject`, which must return 'unknown' in the
                         JScript standard and not 'object')
    --output-dir         The location on disk to write the results files
                         and folders to (defaults to the current directory)
    --timeout            The script will timeout after this many seconds
                         (default 10)
    --windows-xp         Emulate Windows XP (influences the value of
                         environment variables)
    --experimental-neq   [experimental] rewrite `a != b` to `false`
```