### PR TITLE
Use package-relative file paths

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -2,12 +2,13 @@ var controller = require("./_controller");
 var escodegen = require("escodegen");
 var esprima = require("esprima");
 var fs = require("fs");
+var path = require("path");
 var vm = require("vm");
 
 const filename = process.argv[2];
 
 console.log(`Analyzing ${filename}`);
-let code = fs.readFileSync("patch.js", "utf8") + fs.readFileSync(filename, "utf8");
+let code = fs.readFileSync(path.join(__dirname, "patch.js"), "utf8") + fs.readFileSync(filename, "utf8");
 
 if (code.match("<job") || code.match("<script")) { // The sample may actually be a .wsf, which is <job><script>..</script><script>..</script></job>.
 	code = code.replace(/<\??\/?\w+( .*)*\??>/g, ""); // XML tags

--- a/analyze.js
+++ b/analyze.js
@@ -1,8 +1,8 @@
-var esprima = require("esprima");
-var escodegen = require("escodegen");
-var vm = require("vm");
-var fs = require("fs");
 var controller = require("./_controller");
+var escodegen = require("escodegen");
+var esprima = require("esprima");
+var fs = require("fs");
+var vm = require("vm");
 
 const filename = process.argv[2];
 

--- a/run.js
+++ b/run.js
@@ -36,7 +36,6 @@ if (!argv.timeout)
 	console.log("Using a 10 seconds timeout, pass --timeout to specify another timeout in seconds");
 
 let outputDir = argv["output-dir"] || "./";
-outputDir = outputDir.slice(-1) != "/" ? outputDir + "/" : outputDir;
 
 const isFile = path => {
 	try {
@@ -91,11 +90,11 @@ function isDir(path) {
 }
 
 function analyze(file_path, filename, outputDir) {
-	let directory = outputDir + filename + ".results";
+	let directory = path.join(outputDir, filename + ".results");
 	let i = 1;
 	while (isDir(directory)) {
 		i++;
-		directory = outputDir + filename + "." + i + ".results";
+		directory = path.join(outputDir, filename + "." + i + ".results");
 	}
 	fs.mkdirSync(directory);
 	directory += "/"; // For ease of use

--- a/run.js
+++ b/run.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
-var cp = require('child_process');
+var argv = require('minimist')(process.argv.slice(2));
+var columnify = require("columnify");
+var cp = require("child_process");
 var fs = require("fs");
 var walk = require("walk");
-var columnify = require("columnify");
-
-var argv = require('minimist')(process.argv.slice(2));
 
 var help = `box-js is a utility to analyze malicious JavaScript files.
 

--- a/run.js
+++ b/run.js
@@ -4,6 +4,7 @@ var argv = require('minimist')(process.argv.slice(2));
 var columnify = require("columnify");
 var cp = require("child_process");
 var fs = require("fs");
+var path = require("path");
 var walk = require("walk");
 
 var help = `box-js is a utility to analyze malicious JavaScript files.
@@ -15,7 +16,7 @@ Arguments:
 `;
 
 // Read and format JSON flag documentation
-var flags = JSON.parse(fs.readFileSync('flags.json', 'utf8'));
+var flags = JSON.parse(fs.readFileSync(path.join(__dirname, 'flags.json'), 'utf8'));
 flags = columnify(flags, {
     showHeaders: false,
     config: {
@@ -89,7 +90,7 @@ function isDir(path) {
 	}
 }
 
-function analyze(path, filename, outputDir) {
+function analyze(file_path, filename, outputDir) {
 	let directory = outputDir + filename + ".results";
 	let i = 1;
 	while (isDir(directory)) {
@@ -98,7 +99,7 @@ function analyze(path, filename, outputDir) {
 	}
 	fs.mkdirSync(directory);
 	directory += "/"; // For ease of use
-	let worker = cp.fork('./analyze', [path, directory, ...options]);
+	let worker = cp.fork(path.join(__dirname, 'analyze'), [file_path, directory, ...options]);
 	let killTimeout;
 
 	worker.on('message', function(data) {


### PR DESCRIPTION
This PR gives a couple of fixes for things that I've overlooked recently:
- Reference other JS/JSON files relative to `__dirname` (the name of the directory the currently executing script is in), instead of the current working directory. This is important when using the global `box-js` command, as otherwise it cannot find the necessary files
- Use the `path` module to tidy up the construction of file/directory paths (less manual manipulation of trailing slashes)