### PR TITLE
WriteLine should add \r\n

### DIFF
--- a/emulator/FileSystemObject.js
+++ b/emulator/FileSystemObject.js
@@ -25,7 +25,7 @@ function TextStream(filename) {
 		lib.logResource(this.uuid, this.filename, this.buffer);
 	};
 	this.writeline = (line) => {
-		this.buffer = this.buffer + line + "\n";
+		this.buffer = this.buffer + line + "\r\n";
 		lib.writeFile(filename, this.buffer);
 		lib.logResource(this.uuid, this.filename, this.buffer);
 	};


### PR DESCRIPTION
The real WriteLine ends lines with \r\n.

We should maintain this behavior in order for file hashes to be correct.
