### PR TITLE
Check if .git is a directory when printing commit hash.

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -531,3 +531,4 @@ function hoist(obj, scope) {
 		}
 	}
 }
+

--- a/analyze.js
+++ b/analyze.js
@@ -531,4 +531,3 @@ function hoist(obj, scope) {
 		}
 	}
 }
-

--- a/analyze.js
+++ b/analyze.js
@@ -15,7 +15,9 @@ require("./patches/prototype-plugin.js")(acorn);
 
 lib.debug("Analysis launched: " + JSON.stringify(process.argv));
 lib.verbose("Box-js version: " + require("./package.json").version);
-if (fs.existsSync(path.join(__dirname, ".git"))) {
+
+let git_path = path.join(__dirname, ".git");
+if (fs.existsSync(git_path) && fs.lstatSync(git_path).isDirectory()) {
 	lib.verbose("Commit: " + fs.readFileSync(path.join(__dirname, ".git/refs/heads/master"), "utf8").replace(/\n/, ""));
 } else {
 	lib.verbose("No git folder found.");


### PR DESCRIPTION
When using box-js as a submodule `.git` becomes a file instead of a directory.
This makes box-js crash with the following error
```
fs.js:114
    throw err;
    ^

Error: ENOTDIR: not a directory, open '/home/des/project/projectX/box-js/.git/refs/heads/master'
    at Object.openSync (fs.js:443:3)
    at Object.readFileSync (fs.js:343:35)
    at Object.<anonymous> (/home/des/project/projectX/box-js/analyze.js:20:30)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:829:12)
    at startup (internal/bootstrap/node.js:283:19)
```

This merge request adds additional `isDirectory()` check to fix the problem.