### PR TITLE
Path fix for -v and --license

### DIFF
--- a/integrations/export/export.js
+++ b/integrations/export/export.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const argv = require("../../argv.js").export;
 const child_process = require("child_process");
 const fs = require("fs");

--- a/integrations/export/export.js
+++ b/integrations/export/export.js
@@ -65,12 +65,12 @@ Flags:
 }
 
 if (argv.version) {
-	console.log(require("./package.json").version);
+	console.log(require("../../package.json").version);
 	process.exit(0);
 }
 
 if (argv.license) {
-	console.log(fs.readFileSync(__dirname + "/LICENSE", "utf8"));
+	console.log(fs.readFileSync(__dirname + "/../../LICENSE", "utf8"));
 	process.exit(0);
 }
 


### PR DESCRIPTION
Using -v and --license with box-export causes a "not found" error for package.json and the LICENSE file. The paths end up being incorrectly sourced in export.js. Adding the required '../../' and '/../../' to the paths for the files rectifies this issue.